### PR TITLE
release: prepare v1.4.3

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,11 +2,11 @@
 
 **Connect Chat directly to local Codex or DSH: no more shuttling prompts and results—Chat dispatches, supervises, and accepts the executor's work.**
 
-[![v1.4.2](https://img.shields.io/badge/release-v1.4.2-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.2)
+[![v1.4.3](https://img.shields.io/badge/release-v1.4.3-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3)
 [![CI](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[简体中文](README.md) · **[v1.4.2](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.2) · V1 · Local · Continuously maintainer-tested on macOS.** Tag, GitHub Release, and npm publication remain separate release actions. Windows currently has smoke verification of the Codex and DSH npm CLI launch path on GitHub Actions `windows-latest` (Node 22 with actual npm-installed `@openai/codex` and `@deepseek-ai/dsh`); broader Windows environments and client combinations are not claimed fully certified.
+[简体中文](README.md) · **[v1.4.3](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3) · V1 · Local · Continuously maintainer-tested on macOS.** Tag, GitHub Release, and npm publication remain separate release actions. Windows currently has smoke verification of the Codex and DSH npm CLI launch path on GitHub Actions `windows-2025` (Node 22 with actual npm-installed `@openai/codex` and `@deepseek-ai/dsh`); broader Windows environments and client combinations are not claimed fully certified.
 
 ## Before / now
 
@@ -116,7 +116,7 @@ npm install
 npm run build
 ```
 
-The current v1.4.2 release has no one-click installer.
+The current v1.4.3 release has no one-click installer.
 
 ### 3. Register a workspace
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **打通 Chat 与本地 Codex 与 Deepseek harness：不再搬提示词，Chat 直接调度、监督并验收 Codex 与 Deepseek harness。**
 
-[![v1.4.2](https://img.shields.io/badge/release-v1.4.2-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.2)
+[![v1.4.3](https://img.shields.io/badge/release-v1.4.3-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3)
 [![CI](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[English](README.en.md) · **[v1.4.2](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.2) · V1 · 本地运行 · macOS 由维护者持续实测。** tag、GitHub Release 与 npm 发布仍是彼此独立的 release 操作。Windows 侧目前已有 GitHub Actions `windows-latest` 上的 Codex 与 DSH npm CLI 启动路径 smoke 验证（Node 22 + 实际 npm 安装的 `@openai/codex` 与 `@deepseek-ai/dsh`）；更广的 Windows 环境与客户端组合不做全面认证。
+[English](README.en.md) · **[v1.4.3](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3) · V1 · 本地运行 · macOS 由维护者持续实测。** tag、GitHub Release 与 npm 发布仍是彼此独立的 release 操作。Windows 侧目前已有 GitHub Actions `windows-2025` 上的 Codex 与 DSH npm CLI 启动路径 smoke 验证（Node 22 + 实际 npm 安装的 `@openai/codex` 与 `@deepseek-ai/dsh`）；更广的 Windows 环境与客户端组合不做全面认证。
 
 ## 以前 / 现在
 
@@ -117,7 +117,7 @@ npm install
 npm run build
 ```
 
-当前 v1.4.2 没有一键安装器。
+当前 v1.4.3 没有一键安装器。
 
 ### 3. 登记工作区
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,30 @@
 # Release notes
 
-## Unreleased
+## v1.4.3
+
+v1.4.3 hardens Codex app-server handling and Windows path portability while preserving v1.4.x routing compatibility and controlled-write safety.
 
 ### Added
 
 - Add `ENGINEERING_BRIDGE_CODEX_ROUTING_POLICY=explicit` as a Bridge-owned Codex routing hard gate. Each Codex invocation must provide both `model` and `reasoning_effort` before executable resolution or process start; missing or blank values return `CODEX_ROUTING_REQUIRED`. The default remains `inherit` for v1.4.x compatibility, and DSH behavior is unchanged.
+- Add Windows Server 2025 CI coverage alongside Ubuntu.
+
+### Fixed
+
+- Harden Codex app-server JSONL and UTF-8 handling, RPC message validation, unsupported server-request rejection, and bounded, sanitized diagnostics and error classification.
+- Preserve and correlate Codex thread and turn identity from app-server protocol events, and carry bounded in-progress and terminal executor diagnostics through task results.
+- Isolate Windows-specific host assumptions in tests with local Git line-ending policy and explicit platform and path fixtures.
+- Harden Windows workspace-root validation, path containment, and filesystem identity handling, including drive-root and ordinary UNC semantics and native realpath alignment.
+- Update MCP onboarding assertions to compare native realpaths where required.
 
 ### Compatibility
 
 - Invalid routing policy values fail Bridge startup. Explicit routing values continue through the existing Codex `model/list` and reasoning validation and are propagated to `turn/start`.
+- Windows Server 2025 CI broadens automated coverage but is not comprehensive Windows certification; broader Windows environments and client combinations remain unclaimed.
+
+### Safety
+
+- On Windows environments where Node does not expose `fs.constants.O_NOFOLLOW`, affected ordinary-untracked-file controlled `COMMIT` fingerprinting remains fail-closed; v1.4.3 does not substitute a weaker open path or weaken existing security guarantees.
 
 ## v1.4.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engineering-bridge",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engineering-bridge",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-bridge",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A local MCP bridge for supervised read-only Codex and DSH tasks with controlled patch application.",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- bump package and lockfile version to 1.4.3
- publish the accumulated Codex protocol and Windows path/identity work as v1.4.3 release notes
- update README release links/badges and align Windows CI wording to `windows-2025`
- explicitly retain the Windows `O_NOFOLLOW` fail-closed safety boundary

## Scope

This PR contains exactly one commit (`939fdbef7073383cf87c0886c7a56c4ae00ee980`) and five release-prep files only. It does not include the separate Turritopsis pilot commits.

## Verification

- post-APPLY diff scope: exactly 5 files
- `git diff --check`: PASS
- package.json / package-lock.json versions: 1.4.3
- worktree clean after commit
- no tag created yet
- PR #4 code merge and post-merge `main` CI were green before this release-prep commit