### PR TITLE
fix: harden runtime correctness for v1.4.4

### DIFF
--- a/src/executors/codex-executor.ts
+++ b/src/executors/codex-executor.ts
@@ -21,7 +21,8 @@ const ENVIRONMENT_ALLOWLIST = ["PATH", "HOME", "CODEX_HOME", "TMPDIR", "LANG", "
 const MAX_EVIDENCE = 50;
 const MAX_TEXT = 16_384;
 const MAX_EVIDENCE_BYTES = 65_536;
-const MAX_JSONL_LINE_BYTES = 65_536;
+const MAX_PRE_RESPONSE_NOTIFICATION_BYTES = 65_536;
+const MAX_RAW_JSONL_FRAME_BYTES = 8 * 1024 * 1024;
 const DEFAULT_RPC_CALL_TIMEOUT_MS = 30_000;
 // Official npm target of the Codex CLI, derived from a codex.cmd shim's
 // location so a Windows npm install can be launched through Node directly
@@ -359,7 +360,7 @@ export class CodexExecutor implements Executor {
     const stdoutDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
     const handleLine = (rawLine: string): void => {
       if (settled) return;
-      if (Buffer.byteLength(rawLine, "utf8") > MAX_JSONL_LINE_BYTES) { protocolError("jsonl_line_too_large"); return; }
+      if (Buffer.byteLength(rawLine, "utf8") > MAX_RAW_JSONL_FRAME_BYTES) { protocolError("jsonl_line_too_large"); return; }
       const line = rawLine.trim();
       if (!line) return;
       let message: unknown;
@@ -442,7 +443,7 @@ export class CodexExecutor implements Executor {
       if (known && this.turnId === undefined && message.params.threadId === this.threadId &&
         [...this.pending.values()].some((waiter) => waiter.method === "turn/start")) {
         earlyTurnBytes += Buffer.byteLength(rawLine, "utf8");
-        if (earlyTurnBytes > MAX_JSONL_LINE_BYTES) { protocolError("pre_response_events_limit"); return; }
+        if (earlyTurnBytes > MAX_PRE_RESPONSE_NOTIFICATION_BYTES) { protocolError("pre_response_events_limit"); return; }
         earlyTurnNotifications.push(rawLine);
         return;
       }
@@ -527,7 +528,7 @@ export class CodexExecutor implements Executor {
         buffer = buffer.slice(newline + 1);
         handleLine(line);
       }
-      if (!settled && Buffer.byteLength(buffer, "utf8") > MAX_JSONL_LINE_BYTES) protocolError("jsonl_line_too_large");
+      if (!settled && Buffer.byteLength(buffer, "utf8") > MAX_RAW_JSONL_FRAME_BYTES) protocolError("jsonl_line_too_large");
     });
     const flushFinalLine = (): void => {
       if (settled) return;

--- a/src/executors/dsh-executor.ts
+++ b/src/executors/dsh-executor.ts
@@ -296,9 +296,11 @@ export class DshExecutor implements Executor {
         exitImmediate = setImmediate(() => {
           exitImmediate = undefined;
           if (signalProcessGroup(child, this.platform, "SIGTERM")) {
-            terminationResult = code === 0
-              ? this.completedResult(chunks, bytes, truncated, tail)
-              : failure("DSH_EXECUTION_FAILED");
+            if (terminationResult === undefined) {
+              terminationResult = code === 0
+                ? this.completedResult(chunks, bytes, truncated, tail)
+                : failure("DSH_EXECUTION_FAILED");
+            }
             if (killTimer === undefined) killTimer = setTimeout(forceKill, this.timing.killGraceMs);
             return;
           }

--- a/src/tasks/validation-process-runner.ts
+++ b/src/tasks/validation-process-runner.ts
@@ -4,6 +4,8 @@ import {
   type SpawnOptionsWithoutStdio
 } from "node:child_process";
 
+import { signalExecution } from "../executors/executor.js";
+
 const MAX_OUTPUT_TAIL_BYTES = 65_536;
 
 export type ValidationProcessOutcome =
@@ -103,7 +105,9 @@ type Completion =
 export class ValidationProcessRunner {
   constructor(
     private readonly start: ValidationProcessStarter = startProcess,
-    private readonly timer: ValidationTimer = systemTimer
+    private readonly timer: ValidationTimer = systemTimer,
+    private readonly platform: NodeJS.Platform = process.platform,
+    private readonly signaler: typeof signalExecution = signalExecution
   ) {}
 
   run(request: ValidationProcessRequest): Promise<ValidationProcessOutcome> {
@@ -112,9 +116,9 @@ export class ValidationProcessRunner {
     return new Promise((resolve) => {
       let completed = false;
       let outputTail = Buffer.alloc(0);
-      let timedOut = false;
+      let terminationOutcome: "timeout" | "spawn_error" | undefined;
       let timeoutHandle: NodeJS.Timeout | undefined;
-      let dispositionGraceHandle: NodeJS.Timeout | undefined;
+      let terminationGraceHandle: NodeJS.Timeout | undefined;
 
       const complete = (completion: Completion): void => {
         if (completed) {
@@ -127,9 +131,9 @@ export class ValidationProcessRunner {
           timeoutHandle = undefined;
         }
 
-        if (dispositionGraceHandle !== undefined) {
-          this.timer.clear(dispositionGraceHandle);
-          dispositionGraceHandle = undefined;
+        if (terminationGraceHandle !== undefined) {
+          this.timer.clear(terminationGraceHandle);
+          terminationGraceHandle = undefined;
         }
 
         const durationMs = this.timer.now() - startedAt;
@@ -158,6 +162,7 @@ export class ValidationProcessRunner {
       try {
         child = this.start(executable, args, {
           cwd: request.cwd,
+          detached: this.platform !== "win32",
           shell: false,
           stdio: ["pipe", "pipe", "pipe"]
         });
@@ -172,16 +177,48 @@ export class ValidationProcessRunner {
         }
       };
 
+      const signalChild = (signal: NodeJS.Signals): void => {
+        try {
+          this.signaler(child, this.platform, signal);
+        } catch {
+          // The grace periods bound termination even when signaling throws.
+        }
+      };
+
+      const beginTermination = (
+        outcome: "timeout" | "spawn_error"
+      ): void => {
+        if (completed || terminationOutcome !== undefined) {
+          return;
+        }
+        terminationOutcome = outcome;
+
+        if (timeoutHandle !== undefined) {
+          this.timer.clear(timeoutHandle);
+          timeoutHandle = undefined;
+        }
+
+        terminationGraceHandle = this.timer.set(() => {
+          terminationGraceHandle = undefined;
+          terminationGraceHandle = this.timer.set(() => {
+            terminationGraceHandle = undefined;
+            complete({ kind: "termination_error" });
+          }, 1_000);
+          signalChild("SIGKILL");
+        }, 1_000);
+        signalChild("SIGTERM");
+      };
+
       child.stdout.on("data", capture);
       child.stderr.on("data", capture);
       child.on("error", () => {
-        if (!timedOut) {
+        if (terminationOutcome === undefined) {
           complete({ kind: "spawn_error" });
         }
       });
       child.on("close", (exitCode) => {
-        if (timedOut) {
-          complete({ kind: "timeout" });
+        if (terminationOutcome !== undefined) {
+          complete({ kind: terminationOutcome });
           return;
         }
 
@@ -191,26 +228,23 @@ export class ValidationProcessRunner {
             : { kind: "signal" }
         );
       });
+      child.stdin.on("error", () => {
+        beginTermination("spawn_error");
+      });
 
       timeoutHandle = this.timer.set(() => {
         timeoutHandle = undefined;
-        timedOut = true;
-        dispositionGraceHandle = this.timer.set(() => {
-          dispositionGraceHandle = undefined;
-          complete({ kind: "termination_error" });
-        }, 1_000);
-
-        try {
-          child.kill();
-        } catch {
-          // The disposition grace bounds termination even when kill throws.
-        }
+        beginTermination("timeout");
       }, request.timeoutMs);
 
-      if (request.input !== undefined) {
-        child.stdin.write(request.input);
+      try {
+        if (request.input !== undefined) {
+          child.stdin.write(request.input);
+        }
+        child.stdin.end();
+      } catch {
+        beginTermination("spawn_error");
       }
-      child.stdin.end();
     });
   }
 }

--- a/src/workspaces/registered-workspace-registry.ts
+++ b/src/workspaces/registered-workspace-registry.ts
@@ -73,6 +73,7 @@ export class RegisteredWorkspaceRegistry {
   }
 
   findByRoot(canonicalRoot: string): WorkspaceLookup | undefined {
+    this.refreshManualCanonicalRoots();
     const id = this.canonicalRoots.get(canonicalRoot);
     if (id === undefined) return undefined;
     const registration = this.registrations.get(id);
@@ -93,9 +94,20 @@ export class RegisteredWorkspaceRegistry {
       throw new CoreError("WORKSPACE_BOUNDARY_VIOLATION");
     }
     const canonicalRoot = this.canonicalize(root);
+    this.refreshManualCanonicalRoots();
     if (this.canonicalRoots.has(canonicalRoot)) throw new CoreError("WORKSPACE_BOUNDARY_VIOLATION");
     this.registrations.set(id, { root, canonicalRoot, allowWrite, source: "managed" });
     this.canonicalRoots.set(canonicalRoot, id);
+  }
+
+  private refreshManualCanonicalRoots(): void {
+    this.canonicalRoots.clear();
+    for (const [id, registration] of this.registrations) {
+      const canonicalRoot = registration.source === "manual"
+        ? this.canonicalize(registration.root)
+        : registration.canonicalRoot;
+      if (!this.canonicalRoots.has(canonicalRoot)) this.canonicalRoots.set(canonicalRoot, id);
+    }
   }
 
   sourceOf(workspaceId: string): "manual" | "managed" {

--- a/tests/unit/executors/codex-executor.test.ts
+++ b/tests/unit/executors/codex-executor.test.ts
@@ -997,8 +997,8 @@ test("fails promptly with bounded diagnostics for an overlong unterminated Codex
   const invocation = invocations[0];
   assert.ok(invocation);
 
-  invocation.writeStdout("x".repeat(40_000));
-  invocation.writeStdout(`${"y".repeat(40_000)}${secret}`);
+  invocation.writeStdout("x".repeat(4 * 1024 * 1024));
+  invocation.writeStdout(`${"y".repeat(4 * 1024 * 1024)}${secret}`);
 
   const result = await pending;
   assert.equal(result.kind, "failed");

--- a/tests/unit/executors/codex-protocol.test.ts
+++ b/tests/unit/executors/codex-protocol.test.ts
@@ -182,6 +182,7 @@ test("partial UTF-8 chunks and coalesced CRLF messages preserve agent output", a
 });
 
 for (const raw of ["broken-json\n", "[]\n", "null\n", "7\n", '{"method":', "x".repeat(65_537),
+  "oversized-malformed-json".repeat(4_000) + "\n",
   '{"id":1,"result":{},"error":{"code":-1,"message":"bad"}}\n',
   '{"id":1.5,"result":{}}\n', '{"id":null,"result":{}}\n',
   '{"id":1,"error":{"code":"bad","message":"bad"}}\n']) {
@@ -266,10 +267,41 @@ test("an oversized line is explicitly diagnosed without returning any of it", as
   const peer = server();
   const pending = peer.executor.execute(request);
   await tick();
-  peer.raw("private-line".repeat(6_000));
+  peer.raw("private-line" + "x".repeat(8 * 1024 * 1024));
   failed(await pending, "protocol_error", "CODEX_PROTOCOL_ERROR");
   assert.equal(diagnostics(await pending).protocol_error_kind, "jsonl_line_too_large");
   assert.doesNotMatch(JSON.stringify(await pending), /private-line/);
+});
+
+test("newline-terminated command completion over 64 KiB retains evidence without aggregated output", async () => {
+  const frame = { method: "item/completed", params: {
+    threadId: "thread-1", turnId: "turn-1",
+    item: { id: "large-command", type: "commandExecution", status: "completed",
+      command: "cat output.txt", aggregatedOutput: "" }
+  } };
+  assert.ok(Buffer.byteLength(JSON.stringify(frame), "utf8") < 65_536);
+  frame.params.item.aggregatedOutput = "start\n" + "F5_AGGREGATED_OUTPUT_SENTINEL\n".repeat(4_096);
+  const line = JSON.stringify(frame);
+  assert.ok(Buffer.byteLength(line, "utf8") > 65_536);
+
+  const peer = server();
+  const pending = peer.executor.execute(request);
+  await tick();
+  peer.send({ method: "item/commandExecution/outputDelta", params: {
+    threadId: "thread-1", turnId: "turn-1", itemId: "large-command", delta: "start\n"
+  } });
+  peer.raw(`${line}\n`);
+  peer.terminal();
+  const result = await pending;
+  assert.equal(result.kind, "completed", JSON.stringify(diagnostics(result)));
+  assert.equal(diagnostics(result).protocol_error_kind, undefined);
+  if (result.kind === "completed") {
+    assert.equal(result.output, "");
+    assert.deepEqual(result.evidence, [
+      { id: "large-command", type: "commandExecution", status: "completed", command: "cat output.txt" }
+    ]);
+  }
+  assert.doesNotMatch(JSON.stringify(result), /aggregatedOutput|F5_AGGREGATED_OUTPUT_SENTINEL/);
 });
 
 test("uncorrelated item notifications cannot become output or evidence", async () => {

--- a/tests/unit/executors/dsh-executor.test.ts
+++ b/tests/unit/executors/dsh-executor.test.ts
@@ -646,6 +646,37 @@ test("interrupt with a zero exit code still reports interrupted", async () => {
   assert.deepEqual(await pending, { kind: "interrupted", output: "" });
 });
 
+test("interrupt result survives direct exit while the POSIX process group remains alive", async () => {
+  const invocations: Invocation[] = [];
+  const originalKill = process.kill;
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    if (pid !== -424242) throw new Error(`unexpected pid ${pid}`);
+    if (signal === "SIGTERM" || signal === "SIGKILL") return true;
+    throw new Error(`unexpected signal ${String(signal)}`);
+  }) as typeof process.kill;
+  try {
+    const executor = timedExecutor(
+      fakeStarter({ hold: true, pid: 424242 }, invocations),
+      "darwin"
+    );
+    const pending = executor.execute({ taskId: TASK_ID, instruction: "inspect" });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const invocation = invocations[0];
+    assert.ok(invocation);
+    invocation.write("partial answer");
+    await executor.interrupt();
+    invocation.exit(0);
+
+    assert.deepEqual(await settlesWithin(pending), {
+      kind: "interrupted",
+      output: "partial answer"
+    });
+  } finally {
+    process.kill = originalKill;
+  }
+});
+
 test("interrupt without an active child is an invalid state transition", async () => {
   const idle = new DshExecutor(TRUSTED_CWD, fakeStarter({}, []), {});
   await assert.rejects(idle.interrupt(), (error) =>

--- a/tests/unit/tasks/validation-process-runner.test.ts
+++ b/tests/unit/tasks/validation-process-runner.test.ts
@@ -84,7 +84,7 @@ function fakeChild(): FakeChild {
     stdin,
     stdout,
     stderr,
-    pid: 1234,
+    pid: undefined,
     kill(signal?: NodeJS.Signals | number) {
       killSignals.push(signal);
       return true;
@@ -121,6 +121,35 @@ function starterFor(child: FakeChild, invocations: Invocation[]): ValidationProc
   };
 }
 
+interface ExecutionSignalCall {
+  readonly platform: NodeJS.Platform;
+  readonly signal: NodeJS.Signals;
+}
+
+function runnerWithExecutionSignaler(
+  child: FakeChild,
+  timers: ValidationTimer,
+  invocations: Invocation[],
+  platform: NodeJS.Platform,
+  calls: ExecutionSignalCall[]
+): ValidationProcessRunner {
+  const signaler = (
+    _child: ChildProcessWithoutNullStreams,
+    actualPlatform: NodeJS.Platform,
+    signal: NodeJS.Signals
+  ): boolean => {
+    calls.push({ platform: actualPlatform, signal });
+    return true;
+  };
+
+  return Reflect.construct(ValidationProcessRunner, [
+    starterFor(child, invocations),
+    timers,
+    platform,
+    signaler
+  ]) as ValidationProcessRunner;
+}
+
 function request(argv: readonly [string, ...string[]]): ValidationProcessRequest {
   return {
     argv,
@@ -146,6 +175,7 @@ test("passes executable, arguments, cwd, and no-shell pipe options exactly", asy
     args: ["test", "--", "focused"],
     options: {
       cwd: "/trusted/workspace",
+      detached: process.platform !== "win32",
       shell: false,
       stdio: ["pipe", "pipe", "pipe"]
     }
@@ -185,6 +215,142 @@ test("forwards optional stdin input and ends stdin", async () => {
 
   child.close(0);
   await result;
+});
+
+test("contains asynchronous stdin write errors until the validation child closes", async () => {
+  const child = fakeChild();
+  const timers = new ManualTimer();
+  timers.currentMs = 20;
+  const calls: ExecutionSignalCall[] = [];
+  const runner = runnerWithExecutionSignaler(child, timers, [], "linux", calls);
+
+  const result = runner.run({
+    ...request(["validator"]),
+    input: "candidate patch\n"
+  });
+  let settled = false;
+  void result.then(() => {
+    settled = true;
+  });
+
+  const pipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+  let thrownError: unknown;
+  try {
+    child.process.stdin.emit("error", pipeError);
+  } catch (error) {
+    thrownError = error;
+  }
+
+  await Promise.resolve();
+  assert.equal(thrownError, undefined);
+  assert.equal(settled, false);
+  assert.deepEqual(calls, [{ platform: "linux", signal: "SIGTERM" }]);
+
+  child.close(null, "SIGTERM");
+  assert.deepEqual(await result, {
+    kind: "spawn_error",
+    durationMs: 0,
+    outputTail: ""
+  });
+});
+
+test("bounds termination after an asynchronous stdin write error when the child never closes", async () => {
+  const child = fakeChild();
+  const timers = new ManualTimer();
+  timers.currentMs = 20;
+  const calls: ExecutionSignalCall[] = [];
+  const runner = runnerWithExecutionSignaler(child, timers, [], "linux", calls);
+
+  const result = runner.run({
+    ...request(["validator"]),
+    input: "candidate patch\n"
+  });
+  let settled = false;
+  void result.then(() => {
+    settled = true;
+  });
+
+  const pipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+  let thrownError: unknown;
+  try {
+    child.process.stdin.emit("error", pipeError);
+  } catch (error) {
+    thrownError = error;
+  }
+
+  await Promise.resolve();
+  assert.equal(thrownError, undefined);
+  assert.equal(settled, false);
+  assert.deepEqual(calls, [{ platform: "linux", signal: "SIGTERM" }]);
+  assert.equal(timers.pending.size, 1);
+
+  timers.currentMs = 1_020;
+  assert.equal(timers.fireNext(), 1_000);
+  await Promise.resolve();
+  assert.equal(settled, false);
+  assert.deepEqual(calls, [
+    { platform: "linux", signal: "SIGTERM" },
+    { platform: "linux", signal: "SIGKILL" }
+  ]);
+  assert.equal(timers.pending.size, 1);
+
+  timers.currentMs = 2_020;
+  assert.equal(timers.fireNext(), 1_000);
+  assert.deepEqual(await result, {
+    kind: "termination_error",
+    durationMs: 2_000,
+    outputTail: ""
+  });
+});
+
+test("uses execution-tree signaling and two bounded grace periods after timeout", async () => {
+  const child = fakeChild();
+  const timers = new ManualTimer();
+  timers.currentMs = 10;
+  const invocations: Invocation[] = [];
+  const calls: ExecutionSignalCall[] = [];
+  const runner = runnerWithExecutionSignaler(
+    child,
+    timers,
+    invocations,
+    "linux",
+    calls
+  );
+
+  const result = runner.run({
+    ...request(["validator"]),
+    timeoutMs: 50
+  });
+  let settled = false;
+  void result.then(() => {
+    settled = true;
+  });
+
+  timers.currentMs = 60;
+  assert.equal(timers.fireNext(), 50);
+  await Promise.resolve();
+  assert.equal(invocations[0]?.options.detached, true);
+  assert.deepEqual(calls, [{ platform: "linux", signal: "SIGTERM" }]);
+  assert.equal(settled, false);
+  assert.equal(timers.pending.size, 1);
+
+  timers.currentMs = 1_060;
+  assert.equal(timers.fireNext(), 1_000);
+  await Promise.resolve();
+  assert.deepEqual(calls, [
+    { platform: "linux", signal: "SIGTERM" },
+    { platform: "linux", signal: "SIGKILL" }
+  ]);
+  assert.equal(settled, false);
+  assert.equal(timers.pending.size, 1);
+
+  timers.currentMs = 2_060;
+  assert.equal(timers.fireNext(), 1_000);
+  assert.deepEqual(await result, {
+    kind: "termination_error",
+    durationMs: 2_050,
+    outputTail: ""
+  });
 });
 
 test("preserves zero and nonzero numeric exit codes", async () => {
@@ -423,10 +589,20 @@ for (const killBehavior of [
       assert.equal(timers.pending.size, 1);
 
       timers.currentMs = 1_060;
-      timers.fireNext();
+      assert.doesNotThrow(() => timers.fireNext());
+      await Promise.resolve();
+      assert.equal(settled, false);
+      assert.deepEqual(
+        child.killSignals.map((signal) => signal ?? "SIGTERM"),
+        ["SIGTERM", "SIGKILL"]
+      );
+      assert.equal(timers.pending.size, 1);
+
+      timers.currentMs = 2_060;
+      assert.equal(timers.fireNext(), 1_000);
       assert.deepEqual(await result, {
         kind: "termination_error",
-        durationMs: 1_050,
+        durationMs: 2_050,
         outputTail: "before stalled termination"
       });
     }

--- a/tests/unit/workspaces/registered-workspace-registry.test.ts
+++ b/tests/unit/workspaces/registered-workspace-registry.test.ts
@@ -101,6 +101,24 @@ test("registerManaged rejects conflicting ids and occupied canonical roots", () 
   expectCode(() => registry.registerManaged("managed-2", workspaceFixture("managed", "root")), "WORKSPACE_BOUNDARY_VIOLATION");
 });
 
+test("F4: managed registration rejects a manual root whose canonical identity becomes available", () => {
+  const manualRoot = workspaceFixture("manual", "late-root");
+  const canonicalRoot = workspaceFixture("canonical", "late-root");
+  let canonicalAvailable = false;
+  const canonicalize = (root: string): string =>
+    root === manualRoot && canonicalAvailable ? canonicalRoot : root;
+  const registry = new RegisteredWorkspaceRegistry([
+    { id: "manual", root: manualRoot }
+  ], canonicalize);
+
+  canonicalAvailable = true;
+
+  expectCode(
+    () => registry.registerManaged("managed", canonicalRoot),
+    "WORKSPACE_BOUNDARY_VIOLATION"
+  );
+});
+
 test("findByRoot returns the manual registration with its real write access", () => {
   const registry = new RegisteredWorkspaceRegistry([
     { id: "manual", root: ROOT, allow_write: true }


### PR DESCRIPTION
## Summary

This PR closes the v1.4.4 correctness fixes identified in the post-v1.4.3 audit and one real Codex JSONL failure report.

- Harden validation process lifecycle: contain async stdin write errors and bound process-tree termination with TERM → KILL grace periods.
- Accept bounded large Codex JSONL frames while keeping the pre-response notification budget at 64 KiB and retaining a hard 8 MiB transport cap.
- Preserve an already-established DSH interruption result when the direct child exits while its POSIX process group is still alive.
- Refresh manual workspace canonical identity before root lookup/managed registration so a path that becomes canonicalizable cannot be registered under a second ID.
- Update the legacy overlong-JSONL regression fixture to exercise the new 8 MiB hard cap.

## Verification

- Each F1–F5 fix was developed with targeted RED → GREEN regression coverage.
- F5 closure suite: 123/123 PASS.
- GitHub Actions run #63 / `34474001442` on HEAD `231db8db49a1e4caf359ec3e48e81b072b095e63`:
  - Ubuntu: tests PASS, build PASS
  - Windows Server 2025: tests PASS, build PASS
- Final closure review: worktree clean; `git diff --check` clean; 5 commits / 9 files, all within F1–F5 scope.

No version bump, tag, release, or unrelated UX/API work is included here; release metadata remains a separate post-merge step.