### PR TITLE
release: prepare v1.4.4

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,11 +2,11 @@
 
 **Connect Chat directly to local Codex or DSH: no more shuttling prompts and results—Chat dispatches, supervises, and accepts the executor's work.**
 
-[![v1.4.3](https://img.shields.io/badge/release-v1.4.3-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3)
+[![v1.4.4](https://img.shields.io/badge/release-v1.4.4-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.4)
 [![CI](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[简体中文](README.md) · **[v1.4.3](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3) · V1 · Local · Continuously maintainer-tested on macOS.** Tag, GitHub Release, and npm publication remain separate release actions. Windows currently has smoke verification of the Codex and DSH npm CLI launch path on GitHub Actions `windows-2025` (Node 22 with actual npm-installed `@openai/codex` and `@deepseek-ai/dsh`); broader Windows environments and client combinations are not claimed fully certified.
+[简体中文](README.md) · **[v1.4.4](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.4) · V1 · Local · Continuously maintainer-tested on macOS.** Tag, GitHub Release, and npm publication remain separate release actions. Windows currently has smoke verification of the Codex and DSH npm CLI launch path on GitHub Actions `windows-2025` (Node 22 with actual npm-installed `@openai/codex` and `@deepseek-ai/dsh`); broader Windows environments and client combinations are not claimed fully certified.
 
 ## Before / now
 
@@ -116,7 +116,7 @@ npm install
 npm run build
 ```
 
-The current v1.4.3 release has no one-click installer.
+The current v1.4.4 release has no one-click installer.
 
 ### 3. Register a workspace
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **打通 Chat 与本地 Codex 与 Deepseek harness：不再搬提示词，Chat 直接调度、监督并验收 Codex 与 Deepseek harness。**
 
-[![v1.4.3](https://img.shields.io/badge/release-v1.4.3-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3)
+[![v1.4.4](https://img.shields.io/badge/release-v1.4.4-blue)](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.4)
 [![CI](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/wudy29/engineering-bridge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[English](README.en.md) · **[v1.4.3](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.3) · V1 · 本地运行 · macOS 由维护者持续实测。** tag、GitHub Release 与 npm 发布仍是彼此独立的 release 操作。Windows 侧目前已有 GitHub Actions `windows-2025` 上的 Codex 与 DSH npm CLI 启动路径 smoke 验证（Node 22 + 实际 npm 安装的 `@openai/codex` 与 `@deepseek-ai/dsh`）；更广的 Windows 环境与客户端组合不做全面认证。
+[English](README.en.md) · **[v1.4.4](https://github.com/wudy29/engineering-bridge/releases/tag/v1.4.4) · V1 · 本地运行 · macOS 由维护者持续实测。** tag、GitHub Release 与 npm 发布仍是彼此独立的 release 操作。Windows 侧目前已有 GitHub Actions `windows-2025` 上的 Codex 与 DSH npm CLI 启动路径 smoke 验证（Node 22 + 实际 npm 安装的 `@openai/codex` 与 `@deepseek-ai/dsh`）；更广的 Windows 环境与客户端组合不做全面认证。
 
 ## 以前 / 现在
 
@@ -117,7 +117,7 @@ npm install
 npm run build
 ```
 
-当前 v1.4.3 没有一键安装器。
+当前 v1.4.4 没有一键安装器。
 
 ### 3. 登记工作区
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 # Release notes
 
+## v1.4.4
+
+v1.4.4 is a correctness release for validation process lifecycle, Codex app-server JSONL frame compatibility, DSH interruption preservation, and workspace canonical identity handling.
+
+### Fixed
+
+- Contain asynchronous validation stdin write failures and use bounded process-tree termination with SIGTERM followed by SIGKILL grace periods on timeout or stdin failure.
+- Accept legal newline-terminated Codex app-server JSONL frames above 64 KiB up to a Bridge-owned 8 MiB raw-frame hard cap, while keeping the 64 KiB pre-response notification budget unchanged.
+- Preserve an already-established DSH interruption result if the direct child exits while its POSIX process group is still alive.
+- Refresh manual workspace canonical identities before root lookup and managed registration so a root that becomes canonicalizable cannot be registered under a second identity.
+- Update the overlong unterminated JSONL regression fixture to exercise the new 8 MiB hard cap.
+
+### Compatibility
+
+- The 8 MiB raw-frame limit is a Bridge compatibility bound, not a Codex protocol specification maximum. Existing routing and controlled-write semantics are unchanged.
+
+### Safety
+
+- Frames above the 8 MiB hard cap still fail closed; existing JSONL/UTF-8 validation and bounded diagnostic/evidence handling remain in place.
+
+### Verification
+
+- The merged correctness candidate and post-merge `main` both passed GitHub Actions on Ubuntu and Windows Server 2025.
+
 ## v1.4.3
 
 v1.4.3 hardens Codex app-server handling and Windows path portability while preserving v1.4.x routing compatibility and controlled-write safety.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engineering-bridge",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engineering-bridge",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-bridge",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A local MCP bridge for supervised read-only Codex and DSH tasks with controlled patch application.",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Prepare the v1.4.4 release metadata after the correctness fixes were merged into `main`.

This PR contains release-preparation metadata only:

- bump `package.json` and the root `package-lock.json` version from `1.4.3` to `1.4.4`
- update the Chinese and English README release badge/link/current-version text
- prepend the v1.4.4 section to `RELEASE_NOTES.md`

No source, test, workflow, configuration, tag, GitHub Release, or npm publication is included.

## Verification

- Diff is exactly 1 commit / 5 files.
- Release-prep commit: `0f111fe5c8f274984e148ba02f87abde4271bdf0`
- Push CI run #66 / `34492884981`: Ubuntu and Windows Server 2025 both completed successfully, including tests and build.
- The underlying correctness changes had already passed post-merge CI on `main` before this metadata-only commit.

GitHub Release notes will be published separately and may use a bilingual Chinese/English presentation.